### PR TITLE
Setup tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,33 @@
+# github workflow file that runs the tests defined in pytest in src/unit_tests
+# and src/integration_tests
+# This file is run automatically when a pull request is made to the main branch
+# or when a commit is made to the main branch
+# This file is also run when a commit is made to a pull request
+
+name: "Run tests"
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: Install Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.11' 
+    - name: Install dependencies without gpu support
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements_tests.txt
+    - name: Test with pytest
+      run: |
+        pytest -v

--- a/requirements_tests.txt
+++ b/requirements_tests.txt
@@ -1,0 +1,14 @@
+# local package
+-e .
+
+torch --index-url https://download.pytorch.org/whl/cpu
+lightning
+click
+Sphinx
+coverage
+flake8
+python-dotenv>=0.5.1
+dvc
+hydra-core
+pytest
+pandas

--- a/src/configs/config.yaml
+++ b/src/configs/config.yaml
@@ -1,6 +1,6 @@
 hyperparameters:
   batch_size: 32
-  learning_rate: 1e-3
+  learning_rate: 0.001
   epochs: 5
   input_size: 90
   output_size: 1
@@ -9,4 +9,5 @@ hyperparameters:
   dropout_rate: 0.5
   criterion: "MSELoss"
   optimizer: "Adam"
-
+paths:
+  training_data_path: 'data/processed/data.csv'

--- a/src/models/model.py
+++ b/src/models/model.py
@@ -48,6 +48,10 @@ class LightningModel(pl.LightningModule):
             raise NotImplementedError
 
     def forward(self, x):
+        if x.ndim != 2:
+            raise ValueError('Expected input to a 2D tensor')
+        if x.shape[1] != self.hyperparams["input_size"]:
+            raise ValueError(f'Expected each sample to have shape [{self.hyperparams["input_size"]}]')
         return self.model(x)
     
     def training_step(self, batch, batch_idx):

--- a/test.dockerfile
+++ b/test.dockerfile
@@ -1,0 +1,16 @@
+FROM --platform=linux/amd64 python:3.11-slim
+
+# copy inference code
+COPY setup.py setup.py
+COPY src/ src/
+COPY data/ data/
+
+# install python packages
+COPY requirements_tests.txt requirements.txt
+
+WORKDIR /
+
+RUN pip3 install --no-cache-dir -r requirements.txt
+
+# run a sleep command suitable for bashing into the container to check things
+CMD ["sleep", "infinity"]

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,4 @@
+import os
+_TEST_ROOT = os.path.dirname(__file__)  # root of test folder
+_PROJECT_ROOT = os.path.dirname(_TEST_ROOT)  # root of project
+_PATH_DATA = os.path.join(_PROJECT_ROOT, "Data")  # root of data

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1,0 +1,46 @@
+#from tests import _PATH_DATA
+import pandas as pd
+import yaml
+from src.models.train_model import load_data
+from src.models.train_model import normalize_data
+from tests import _PROJECT_ROOT
+import os  
+import os.path
+import pytest
+
+def get_cfg():
+    with open(os.path.join(_PROJECT_ROOT, "src/configs/config.yaml"), "r") as yaml_file:
+        cfg = yaml.safe_load(yaml_file)
+ 
+    return cfg  
+
+@pytest.mark.skipif(not os.path.exists(get_cfg()["paths"]["training_data_path"]), reason="Data files not found")
+def test_data_shape():
+    cfg = get_cfg()
+    data = load_data(cfg["paths"]["training_data_path"]) 
+    assert len(data) == 66595, "Dataset did not have the correct number of samples"
+    assert data.shape[1] == cfg["hyperparameters"]["input_size"] + 1, "Dataset did not have the correct number of columns"
+   
+@pytest.mark.skipif(not os.path.exists(get_cfg()["paths"]["training_data_path"]), reason="Data files not found") 
+def test_x_y_split():
+    cfg = get_cfg()
+    data = load_data(cfg["paths"]["training_data_path"])
+    x,y = normalize_data(data)
+    assert x.shape[1] == cfg["hyperparameters"]["input_size"], "Features do not have the correct shape"
+    assert len(y.shape) == cfg["hyperparameters"]["output_size"], "Targets do not have the correct shape"
+    assert y.min() >= -1437 and y.max() <= 156, "Targets not in expected range"
+
+@pytest.mark.skipif(not os.path.exists(get_cfg()["paths"]["training_data_path"]), reason="Data files not found")
+def test_normalization(): 
+    cfg = get_cfg()
+    data = load_data(cfg["paths"]["training_data_path"]) 
+    x,_ = normalize_data(data)
+    
+    # for every column in the input values, apply a min max normalization
+    for i in range(x.shape[1]):
+        x[:,i] = (x[:,i] - x[:,i].min()) / (x[:,i].max() - x[:,i].min())
+        
+    x_vals = []
+    for x_i in x:
+      x_vals.extend(x_i.tolist())
+    assert all((pd.isna(x_val) or (x_val >= 0 and x_val <= 1)) for x_val in x_vals) == True, "Features are not normalized correctly"

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,0 +1,58 @@
+
+from src.models.model import LightningModel
+import yaml
+from src.models.train_model import load_data
+from src.models.train_model import normalize_data
+from tests import _PROJECT_ROOT
+import os
+import pytest
+import torch
+from contextlib import nullcontext as does_not_raise
+
+def get_hparams():
+    with open(os.path.join("", "src/configs/config.yaml"), "r") as yaml_file: #_PROJECT_ROOT
+        cfg = yaml.safe_load(yaml_file)
+        
+    hparams ={  "lr": cfg["hyperparameters"]["learning_rate"],
+                "epochs": cfg["hyperparameters"]["epochs"],
+                "batch_size": cfg["hyperparameters"]["batch_size"],
+                "input_size": cfg["hyperparameters"]["input_size"],
+                "output_size": cfg["hyperparameters"]["output_size"],
+                "hidden_size": cfg["hyperparameters"]["hidden_size"],
+                "num_layers":  cfg["hyperparameters"]["num_layers"],
+                "criterion":  cfg["hyperparameters"]["criterion"],
+                "optimizer":  cfg["hyperparameters"]["optimizer"],
+                }  
+    return hparams  
+
+def get_paths():
+    with open(os.path.join("", "src/configs/config.yaml"), "r") as yaml_file: #_PROJECT_ROOT
+        cfg = yaml.safe_load(yaml_file)
+        
+    paths = {  "training_data_path": cfg["paths"]["training_data_path"],
+                }  
+    return paths  
+
+@pytest.mark.skipif(not os.path.exists(get_paths()["training_data_path"]), reason="Data files not found")
+def test_model_output():
+    data = load_data(get_paths()["training_data_path"])
+    x,_ = normalize_data(data)
+    
+    hparams = get_hparams() 
+        
+    model = LightningModel(hparams)
+    y_pred = model(x[:1])
+    
+    assert y_pred.shape[0] == hparams["output_size"], "Model output has not the correct shape"
+
+@pytest.mark.parametrize("test_input,expectation",
+    [(torch.randn(1,90), does_not_raise()),
+     (torch.randn(1,2,3), pytest.raises(ValueError, match='Expected input to a 2D tensor')),
+     (torch.randn(20,30), pytest.raises(ValueError, match=f'Expected each sample to have shape \[{get_hparams()["input_size"]}\]')),
+    ],)
+def test_error_on_wrong_shape(test_input, expectation):
+    hparams = get_hparams() 
+    model = LightningModel(hparams)
+    
+    with expectation:
+        model(test_input)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -10,7 +10,7 @@ import torch
 from contextlib import nullcontext as does_not_raise
 
 def get_hparams():
-    with open(os.path.join("", "src/configs/config.yaml"), "r") as yaml_file: #_PROJECT_ROOT
+    with open(os.path.join(_PROJECT_ROOT, "src/configs/config.yaml"), "r") as yaml_file: 
         cfg = yaml.safe_load(yaml_file)
         
     hparams ={  "lr": cfg["hyperparameters"]["learning_rate"],
@@ -26,7 +26,7 @@ def get_hparams():
     return hparams  
 
 def get_paths():
-    with open(os.path.join("", "src/configs/config.yaml"), "r") as yaml_file: #_PROJECT_ROOT
+    with open(os.path.join(_PROJECT_ROOT, "src/configs/config.yaml"), "r") as yaml_file:
         cfg = yaml.safe_load(yaml_file)
         
     paths = {  "training_data_path": cfg["paths"]["training_data_path"],

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -1,0 +1,80 @@
+import yaml
+from src.models.model import LightningModel
+import torch
+from src.models.train_model import load_data
+from src.models.train_model import train
+from tests import _PROJECT_ROOT
+import os
+import pytest
+
+def get_hparams():
+    with open(os.path.join(_PROJECT_ROOT, "src/configs/config.yaml"), "r") as yaml_file:
+        cfg = yaml.safe_load(yaml_file)
+        
+    hparams ={  "lr": cfg["hyperparameters"]["learning_rate"],
+                "epochs": cfg["hyperparameters"]["epochs"],
+                "batch_size": cfg["hyperparameters"]["batch_size"],
+                "input_size": cfg["hyperparameters"]["input_size"],
+                "output_size": cfg["hyperparameters"]["output_size"],
+                "hidden_size": cfg["hyperparameters"]["hidden_size"],
+                "num_layers":  cfg["hyperparameters"]["num_layers"],
+                "criterion":  cfg["hyperparameters"]["criterion"],
+                "optimizer":  cfg["hyperparameters"]["optimizer"],
+                }  
+    return hparams  
+
+def get_paths():
+    with open(os.path.join(_PROJECT_ROOT, "src/configs/config.yaml"), "r") as yaml_file:
+        cfg = yaml.safe_load(yaml_file)
+        
+    paths = {  "training_data_path": cfg["paths"]["training_data_path"],
+                }  
+    return paths  
+
+@pytest.mark.skipif(not os.path.exists(get_paths()["training_data_path"]), reason="Data files not found")
+def test_model_created():
+    data = load_data(get_paths()["training_data_path"])
+    sample_data = data[:5]
+    hparams = get_hparams()
+
+    # Call the train function with sample data and hyperparameters
+    model = train(sample_data, hparams)
+
+    # Assert that the returned model is not None
+    assert model is not None, "Model not instantiated."
+    assert isinstance(model, LightningModel), "Model not instance of specified model."
+
+@pytest.mark.skipif(not os.path.exists(get_paths()["training_data_path"]), reason="Data files not found")
+def test_model_hyperparameters():
+    data = load_data(get_paths()["training_data_path"])
+    sample_data = data[:5]  
+    hparams = get_hparams()   
+    print(hparams["lr"])
+    # Call the train function with sample data and hyperparameters
+    model = train(sample_data, hparams)
+
+    # Assert hyperparameters
+    if hparams["criterion"] == "MSELoss":
+        assert isinstance(model.loss, torch.nn.MSELoss), "Incorrect loss used."
+    elif hparams["criterion"] == "NLLLoss":
+        assert isinstance(model.loss, torch.nn.NLLLoss), "Incorrect loss used."
+    if hparams["optimizer"] == "Adam":
+        assert isinstance(model.configure_optimizers(), torch.optim.Adam), "Incorrect optimizer used."
+    elif hparams["optimizer"] == "SGD":
+        assert isinstance(model.configure_optimizers(), torch.optim.SGD), "Incorrect optimizer used."
+        
+@pytest.mark.skipif(not os.path.exists(get_paths()["training_data_path"]), reason="Data files not found")  
+def test_model_logs():
+    data = load_data(get_paths()["training_data_path"])
+    sample_data = data[:5]
+    hparams = get_hparams()    
+
+    # Call the train function with sample data and hyperparameters
+    model = train(sample_data, hparams)
+        
+    # Assert logged loss
+    assert model.logger.log_dir is not None, "Train loss has not been logged."
+    
+    #assert logged_loss is not None, "Train loss has not been logged."
+    #assert isinstance(logged_loss, torch.Tensor), "Logged train loss is not a tensor."
+    #assert logged_loss.requires_grad is False, "Logged train loss should not require gradients."


### PR DESCRIPTION
In this branch unit tests for the inital data and model setup are implemented. The tests are located in the folder tests/, and can be executed using pytest. The coverage currently is 91%.

Few changes to the model and training have been made:
- model: raise errors for incorrect input shape in forward
- training parametrize path to train data and seperate normalization of features
